### PR TITLE
move functions to /autoload

### DIFF
--- a/autoload/textobj/between.vim
+++ b/autoload/textobj/between.vim
@@ -1,0 +1,53 @@
+function! textobj#between#select_a()  "{{{1
+  return s:select(0)
+endfunction
+
+
+
+function! textobj#between#select_i()  "{{{1
+  return s:select(1)
+endfunction
+
+
+
+function! s:select(in)  "{{{1
+  let c = getchar()
+  if type(c) == type(0)
+    let c = nr2char(c)
+  endif
+  if c !~ '[[:print:]]'
+    return 0
+  endif
+
+  let save_ww = &whichwrap
+  set whichwrap=h,l
+
+  try
+    let pos = getpos('.')
+    let pat = c == '\' ? '\\' : '\V' . c
+    for i in range(v:count1)
+      if !search(pat, 'bW')
+        return 0
+      endif
+    endfor
+    if a:in
+      normal! l
+    endif
+    let start = getpos('.')
+
+    call setpos('.', pos)
+    for i in range(v:count1)
+      if !search(pat, 'W')
+        return 0
+      endif
+    endfor
+    if a:in
+      normal! h
+    endif
+    let end = getpos('.')
+    return ['v', start, end]
+  finally
+    let &whichwrap = save_ww
+  endtry
+endfunction
+

--- a/plugin/textobj/between.vim
+++ b/plugin/textobj/between.vim
@@ -12,69 +12,14 @@ let g:loaded_textobj_between = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-
 " Interface  "{{{1
 call textobj#user#plugin('between', {
 \      '-': {
-\        '*sfile*': expand('<sfile>:p'),
-\        'select-a': 'af',  '*select-a-function*': 's:select_a',
-\        'select-i': 'if',  '*select-i-function*': 's:select_i',
+\        'select-a': 'af',  '*select-a-function*': 'textobj#between#select_a',
+\        'select-i': 'if',  '*select-i-function*': 'textobj#between#select_i',
 \      }
 \    })
 
-
-function! s:select_a()  "{{{2
-  return s:select(0)
-endfunction
-
-
-
-function! s:select_i()  "{{{2
-  return s:select(1)
-endfunction
-
-
-
-function! s:select(in)  "{{{2
-  let c = getchar()
-  if type(c) == type(0)
-    let c = nr2char(c)
-  endif
-  if c !~ '[[:print:]]'
-    return 0
-  endif
-
-  let save_ww = &whichwrap
-  set whichwrap=h,l
-
-  try
-    let pos = getpos('.')
-    let pat = c == '\' ? '\\' : '\V' . c
-    for i in range(v:count1)
-      if !search(pat, 'bW')
-        return 0
-      endif
-    endfor
-    if a:in
-      normal! l
-    endif
-    let start = getpos('.')
-
-    call setpos('.', pos)
-    for i in range(v:count1)
-      if !search(pat, 'W')
-        return 0
-      endif
-    endfor
-    if a:in
-      normal! h
-    endif
-    let end = getpos('.')
-    return ['v', start, end]
-  finally
-    let &whichwrap = save_ww
-  endtry
-endfunction
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
script local functions are moved in textobj#between# namespace.
this makes Vim start faster. (in my environment, elapsed time to load
/plugin/between.vim declines from 8 ms to 1.5 ms)
