### PR TITLE
Support dot-repeating

### DIFF
--- a/autoload/textobj/between.vim
+++ b/autoload/textobj/between.vim
@@ -6,20 +6,39 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! textobj#between#select_a()
-  return s:select(0)
-endfunction
+let s:edge_char = ''
 
 function! textobj#between#select_i()
-  return s:select(1)
+  call s:getchar()
+  return "\<Plug>(textobj-betweenimpl-i)"
 endfunction
 
-function! s:select(in)
+function! textobj#between#select_a()
+  call s:getchar()
+  return "\<Plug>(textobj-betweenimpl-a)"
+endfunction
+
+function! s:getchar()
   let c = getchar()
   if type(c) == type(0)
     let c = nr2char(c)
   endif
   if c !~ '[[:print:]]'
+    return 0
+  endif
+  let s:edge_char = c
+endfunction
+
+function! textobj#between#impl_select_a()
+  return s:select(0)
+endfunction
+
+function! textobj#between#impl_select_i()
+  return s:select(1)
+endfunction
+
+function! s:select(in)
+  if s:edge_char ==# ''
     return 0
   endif
 
@@ -28,7 +47,7 @@ function! s:select(in)
 
   try
     let pos = getpos('.')
-    let pat = c == '\' ? '\\' : '\V' . c
+    let pat = s:edge_char == '\' ? '\\' : '\V' . s:edge_char
     for i in range(v:count1)
       if !search(pat, 'bW')
         return 0

--- a/plugin/textobj/between.vim
+++ b/plugin/textobj/between.vim
@@ -12,12 +12,17 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 " Interface  "{{{1
-call textobj#user#plugin('between', {
+call textobj#user#plugin('betweenimpl', {
 \      '-': {
-\        'select-a': 'af',  '*select-a-function*': 'textobj#between#select_a',
-\        'select-i': 'if',  '*select-i-function*': 'textobj#between#select_i',
+\        'select-a': 'af',  '*select-a-function*': 'textobj#between#impl_select_a',
+\        'select-i': 'if',  '*select-i-function*': 'textobj#between#impl_select_i',
 \      }
 \    })
+
+omap <expr> <Plug>(textobj-between-a) textobj#between#select_a()
+vmap <expr> <Plug>(textobj-between-a) textobj#between#select_a()
+omap <expr> <Plug>(textobj-between-i) textobj#between#select_i()
+vmap <expr> <Plug>(textobj-between-i) textobj#between#select_i()
 
 
 let &cpo = s:save_cpo

--- a/test/.themisrc
+++ b/test/.themisrc
@@ -1,0 +1,1 @@
+call themis#helper('command').with(themis#helper('assert'))

--- a/test/testobj_between.vimspec
+++ b/test/testobj_between.vimspec
@@ -1,0 +1,88 @@
+Describe textobj-between-i
+  Before all
+    omap @ <Plug>(textobj-between-i)
+    vmap @ <Plug>(textobj-between-i)
+  End
+
+  After all
+    ounmap @
+    vunmap @
+  End
+
+  Before each
+    % delete _
+  End
+
+  It selects a text-block between a specified char (Operator-pending mode)
+    call setline(1, 'text/text-block/text')
+    normal f-d@/
+    Assert Equals(getline(1), 'text//text')
+
+    call setline(1, '\text-block\')
+    normal ld@\
+    Assert Equals(getline(1), '\\')
+  End
+
+  It selects a text-block between a specified char (Visual mode)
+    call setline(1, 'text/text-block/text')
+    normal f-v@/d
+    Assert Equals(getline(1), 'text//text')
+
+    call setline(1, '\text-block\')
+    normal lv@\d
+    Assert Equals(getline(1), '\\')
+  End
+
+  It is dot-repeatable
+    call setline(1, '/text-block/')
+    normal ld@/
+    call setline(1, '/text-block/')
+    normal .
+    Assert Equals(getline(1), '//')
+  End
+End
+
+Describe textobj-between-a
+  Before all
+    omap @ <Plug>(textobj-between-a)
+    vmap @ <Plug>(textobj-between-a)
+  End
+
+  After all
+    ounmap @
+    vunmap @
+  End
+
+  Before each
+    % delete _
+  End
+
+  It selects a text-block that starts and ends with a specified char (Operator-pending mode)
+    call setline(1, 'text/text-block/text')
+    normal f-d@/
+    Assert Equals(getline(1), 'texttext')
+
+    call setline(1, '\text-block\')
+    normal d@\
+    Assert Equals(getline(1), '')
+  End
+
+  It selects a text-block that starts and ends with a specified char (Visual mode)
+    call setline(1, 'text/text-block/text')
+    normal f-v@/d
+    Assert Equals(getline(1), 'texttext')
+
+    call setline(1, '\text-block\')
+    normal lv@\d
+    Assert Equals(getline(1), '')
+  End
+
+  It is dot-repeatable
+    call setline(1, '/text-block/')
+    normal ld@/
+
+    call setline(1, 'text/text-block/text')
+    normal f-.
+    Assert Equals(getline(1), 'texttext')
+  End
+End


### PR DESCRIPTION
表題の通り、ドットリピートができるようにしました。
仕掛けとしましては、下記のコードを参考にしていただくと良いのですが、
```vim
let s:ExecutedTimes = 0

function! s:Mapping()
  let s:ExecutedTimes += 1
  return "oa\<ESC>"
endfunction

nnoremap <expr> @ <SID>Mapping()

new
normal @
normal .
echo s:ExecutedTimes "=> 1
```
のように、Vimはドットリピート時にはマッピング先の関数を再評価しない（ようだ）というのを利用しています。