### PR TITLE
Fix default-key-mappings are not defined properly

### DIFF
--- a/plugin/textobj/between.vim
+++ b/plugin/textobj/between.vim
@@ -24,6 +24,20 @@ vmap <expr> <Plug>(textobj-between-a) textobj#between#select_a()
 omap <expr> <Plug>(textobj-between-i) textobj#between#select_i()
 vmap <expr> <Plug>(textobj-between-i) textobj#between#select_i()
 
+" Overwrite default key mappings and a command defined by textobj-user
+function! s:define_default_key_mappings(force_overwrite)
+  let modifier = a:force_overwrite ? '' : '<unique>'
+  execute 'silent! omap' modifier 'af <Plug>(textobj-between-a)'
+  execute 'silent! vmap' modifier 'af <Plug>(textobj-between-a)'
+  execute 'silent! omap' modifier 'if <Plug>(textobj-between-i)'
+  execute 'silent! vmap' modifier 'if <Plug>(textobj-between-i)'
+endfunction
+command! -bang -bar TextobjBetweenDefaultKeyMappings
+      \ call s:define_default_key_mappings(<bang>0)
+if !get(g:, 'textobj_between_no_default_key_mappings', 0)
+  TextobjBetweenDefaultKeyMappings!
+endif
+
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/textobj/between.vim
+++ b/plugin/textobj/between.vim
@@ -24,7 +24,7 @@ vmap <expr> <Plug>(textobj-between-a) textobj#between#select_a()
 omap <expr> <Plug>(textobj-between-i) textobj#between#select_i()
 vmap <expr> <Plug>(textobj-between-i) textobj#between#select_i()
 
-" Overwrite default key mappings and a command defined by textobj-user
+" Overwrite default-key-mappings and a command defined by textobj-user
 function! s:define_default_key_mappings(force_overwrite)
   let modifier = a:force_overwrite ? '' : '<unique>'
   execute 'silent! omap' modifier 'af <Plug>(textobj-between-a)'
@@ -37,6 +37,9 @@ command! -bang -bar TextobjBetweenDefaultKeyMappings
 if !get(g:, 'textobj_between_no_default_key_mappings', 0)
   TextobjBetweenDefaultKeyMappings!
 endif
+
+" Delete this because this may make users confused
+delcommand TextobjBetweenimplDefaultKeyMappings
 
 
 let &cpo = s:save_cpo

--- a/test/testobj_between.vimspec
+++ b/test/testobj_between.vimspec
@@ -1,41 +1,31 @@
 Describe textobj-between-i
-  Before all
-    omap @ <Plug>(textobj-between-i)
-    vmap @ <Plug>(textobj-between-i)
-  End
-
-  After all
-    ounmap @
-    vunmap @
-  End
-
   Before each
     % delete _
   End
 
   It selects a text-block between a specified char (Operator-pending mode)
     call setline(1, 'text/text-block/text')
-    normal f-d@/
+    normal f-dif/
     Assert Equals(getline(1), 'text//text')
 
     call setline(1, '\text-block\')
-    normal ld@\
+    normal ldif\
     Assert Equals(getline(1), '\\')
   End
 
   It selects a text-block between a specified char (Visual mode)
     call setline(1, 'text/text-block/text')
-    normal f-v@/d
+    normal f-vif/d
     Assert Equals(getline(1), 'text//text')
 
     call setline(1, '\text-block\')
-    normal lv@\d
+    normal lvif\d
     Assert Equals(getline(1), '\\')
   End
 
   It is dot-repeatable
     call setline(1, '/text-block/')
-    normal ld@/
+    normal ldif/
     call setline(1, '/text-block/')
     normal .
     Assert Equals(getline(1), '//')
@@ -43,46 +33,55 @@ Describe textobj-between-i
 End
 
 Describe textobj-between-a
-  Before all
-    omap @ <Plug>(textobj-between-a)
-    vmap @ <Plug>(textobj-between-a)
-  End
-
-  After all
-    ounmap @
-    vunmap @
-  End
-
   Before each
     % delete _
   End
 
   It selects a text-block that starts and ends with a specified char (Operator-pending mode)
     call setline(1, 'text/text-block/text')
-    normal f-d@/
+    normal f-daf/
     Assert Equals(getline(1), 'texttext')
 
     call setline(1, '\text-block\')
-    normal d@\
+    normal daf\
     Assert Equals(getline(1), '')
   End
 
   It selects a text-block that starts and ends with a specified char (Visual mode)
     call setline(1, 'text/text-block/text')
-    normal f-v@/d
+    normal f-vaf/d
     Assert Equals(getline(1), 'texttext')
 
     call setline(1, '\text-block\')
-    normal lv@\d
+    normal lvaf\d
     Assert Equals(getline(1), '')
   End
 
   It is dot-repeatable
     call setline(1, '/text-block/')
-    normal ld@/
+    normal ldaf/
 
     call setline(1, 'text/text-block/text')
     normal f-.
     Assert Equals(getline(1), 'texttext')
+  End
+End
+
+Describe :TextobjBetweenDefaultKeyMappings
+  Before each
+    onoremap if <Plug>(dummy-rhs)
+    vnoremap af <Plug>(dummy-rhs)
+  End
+
+  It doesn't overwrite key-mappings when "!" isn't specified
+    TextobjBetweenDefaultKeyMappings
+    Assert Equal(maparg('if', 'o'), '<Plug>(dummy-rhs)')
+    Assert Equal(maparg('af', 'v'), '<Plug>(dummy-rhs)')
+  End
+
+  It overwrites key-mappings when "!" is specified
+    TextobjBetweenDefaultKeyMappings!
+    Assert Equal(maparg('if', 'o'), '<Plug>(textobj-between-i)')
+    Assert Equal(maparg('af', 'v'), '<Plug>(textobj-between-a)')
   End
 End


### PR DESCRIPTION
https://github.com/thinca/vim-textobj-between/pull/4 にて、デフォルトキーマッピングがちゃんと設定されてなかったのを修正しました。