### PR TITLE
Fix g:textobj_between_no_default_mappings doesn't work

### DIFF
--- a/plugin/textobj/between.vim
+++ b/plugin/textobj/between.vim
@@ -14,8 +14,8 @@ set cpo&vim
 " Interface  "{{{1
 call textobj#user#plugin('betweenimpl', {
 \      '-': {
-\        'select-a': 'af',  '*select-a-function*': 'textobj#between#impl_select_a',
-\        'select-i': 'if',  '*select-i-function*': 'textobj#between#impl_select_i',
+\        'select-a': [],  '*select-a-function*': 'textobj#between#impl_select_a',
+\        'select-i': [],  '*select-i-function*': 'textobj#between#impl_select_i',
 \      }
 \    })
 


### PR DESCRIPTION
Fixes https://github.com/thinca/vim-textobj-between/issues/6.